### PR TITLE
fix: radop Style not in center after selection

### DIFF
--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -10,30 +10,30 @@
 
   :global {
     .ant-radio-inner {
-      width: 20px;
-      height: 20px;
+      width: 40px;
+      height: 40px;
     }
 
     .ant-radio-wrapper {
-      font-size: 17px;
+      font-size: 30px;
     }
 
     .ant-radio-inner::after {
-      width: 12px;
-      height: 12px;
+      width: 26px;
+      height: 26px;
       border-radius: 50%;
-      top: 3px;
-      left: 3px;
+      top: 6px;
+      left: 6px;
     }
   }
 }
 
 .fixRadioVerticalStyle {
-  margin-left: 15px;
-  padding: 10px 10px 10px 0px;
+  margin-left: 30px;
+  padding: 21px 21px 21px 0px;
   color: #000;
   border-bottom: 1px solid #ddd;
-  font-size: 17px;
+  font-size: 34px;
 
   .titleDiv {
     margin-bottom: 28px;
@@ -93,7 +93,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 44px;
+    height: 88px;
     border-bottom: 1px solid #ddd;
   }
 }
@@ -129,7 +129,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 44px;
+    height: 88px;
     border-bottom: 1px solid #ddd;
   }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48704410/72779529-2479ba00-3c57-11ea-8ee0-9039fefaa086.png)
