### PR TITLE
doc: NomarInput and ExtraInput and NomarTextArea

### DIFF
--- a/src/components/ExtraInput/index.md
+++ b/src/components/ExtraInput/index.md
@@ -37,6 +37,14 @@ theme: {
 }
 ```
 
+`extraInput` 类型在属性 `editable` 设置为 `false` 时，文字样式会变淡，如果自定义的话可以在 `config/config.ts` 增加如下代码：
+
+```js
+theme: {
+  '@color-text-disabled': '#000',
+}
+```
+
 ## 组件使用
 
 ### PriceInput

--- a/src/components/NomarInput/index.md
+++ b/src/components/NomarInput/index.md
@@ -36,6 +36,16 @@ theme: {
 }
 ```
 
+`input` 类型在属性 `editable` 设置为 `false` 时，文字样式会变淡，如果自定义的话可以在 `config/config.ts` 增加如下代码：
+
+```js
+theme: {
+  '@color-text-disabled': '#000',
+}
+```
+
+
+
 ## 组件使用
 
 ### NomarInput

--- a/src/components/NomarTextArea/index.md
+++ b/src/components/NomarTextArea/index.md
@@ -33,6 +33,14 @@ theme: {
 }
 ```
 
+`area` 类型在属性 `editable` 设置为 `false` 时，文字样式会变淡，如果自定义的话可以在 `config/config.ts` 增加如下代码：
+
+```js
+theme: {
+  '@color-text-disabled': '#000',
+}
+```
+
 ## 组件使用
 
 ### NomarArea


### PR DESCRIPTION
When the text is set to non editable, the text color will fade。If you want to customize the color, you can use insert '@color-text-disabled' in config/config.js