### PR TITLE
NomarRadio 新增  props allowUnChecked

### DIFF
--- a/src/components/NomarRadio/demo/index.tsx
+++ b/src/components/NomarRadio/demo/index.tsx
@@ -87,6 +87,7 @@ const DfromRadioTextPage: FC = () => {
       type: 'radio',
       fieldProps: 'userRadio3',
       required: true,
+      allowUnChecked: false,
       data: foodList,
       title: '喜欢的食物',
       radioType: 'vertical',

--- a/src/components/NomarRadio/index.md
+++ b/src/components/NomarRadio/index.md
@@ -31,6 +31,7 @@ title: Radio
 | alias | data 数据源的别名 | object | { label: 'label', value: 'value' } | 否 |
 | renderHeader | 组件头部 | `number` or `string` | - | 否 |
 | className | 类名 | string | - | 否 |
+| allowUnChecked | 允许取消选中 | boolean | true | 否 |
 
 ## 备注
 

--- a/src/components/NomarRadio/index.tsx
+++ b/src/components/NomarRadio/index.tsx
@@ -28,6 +28,7 @@ export interface INomarRadioProps {
   disabled?: boolean;
   alias?: IAliasProps;
   className?: string;
+  allowUnChecked?: boolean;
 }
 
 const NomarRadio: FC<INomarRadioProps> = props => {
@@ -38,6 +39,7 @@ const NomarRadio: FC<INomarRadioProps> = props => {
     coverStyle,
     fieldProps,
     required = false,
+    allowUnChecked = true,
     rules,
     title,
     data = [],
@@ -85,6 +87,7 @@ const NomarRadio: FC<INomarRadioProps> = props => {
       }}
     >
       <NomarRadioGroup
+        allowUnChecked={allowUnChecked}
         data={aliasData}
         positionType={positionType}
         radioType={radioType}
@@ -104,9 +107,7 @@ const NomarRadio: FC<INomarRadioProps> = props => {
           {isVertical && (
             <div className="alitajs-dform-vertical-title">
               {required && hasStar && <span className="alitajs-dform-redStar">*</span>}
-              <span className="alitajs-dform-title">
-                {title}
-              </span>
+              <span className="alitajs-dform-title">{title}</span>
               {subTitle}
             </div>
           )}
@@ -118,9 +119,7 @@ const NomarRadio: FC<INomarRadioProps> = props => {
           >
             <List.Item key={fieldProps} extra={RadioGroup()}>
               {required && hasStar && <span className="alitajs-dform-redStar">*</span>}
-              <span className="alitajs-dform-title">
-                {title}
-              </span>
+              <span className="alitajs-dform-title">{title}</span>
             </List.Item>
           </div>
         </React.Fragment>

--- a/src/components/NomarRadio/radioGroup.tsx
+++ b/src/components/NomarRadio/radioGroup.tsx
@@ -15,6 +15,7 @@ export interface INomarRadioGroupProps {
   onChange: (currentActiveLink: string | number | undefined, flag: string) => void;
   coverStyle?: React.CSSProperties;
   className?: string;
+  allowUnChecked?: boolean;
 }
 
 const RadioGroup: FC<INomarRadioGroupProps> = props => {
@@ -27,6 +28,7 @@ const RadioGroup: FC<INomarRadioGroupProps> = props => {
     disabled = false,
     coverStyle,
     className = '',
+    allowUnChecked,
   } = props;
   // const [preValue, setPreValue] = useState<string | number | undefined>(undefined);
   const [activeValue, setActiveValue] = useState<string | number | undefined>(undefined);
@@ -81,8 +83,10 @@ const RadioGroup: FC<INomarRadioGroupProps> = props => {
     const filter = data.filter(item => item.value === dataItem?.value);
     if (filter && filter.length) {
       if (dataItem?.value === initValue) {
-        onChange(undefined, 'change');
-        setActiveValue(undefined);
+        if (allowUnChecked) {
+          onChange(undefined, 'change');
+          setActiveValue(undefined);
+        }
       } else {
         onChange(dataItem?.value, 'change');
         setActiveValue(dataItem?.value);
@@ -120,10 +124,13 @@ const RadioGroup: FC<INomarRadioGroupProps> = props => {
           >
             {item.value === activeValue && <div className="alitajs-dform-radio-inner-button"></div>}
           </div>
-          <div className={classnames({
-            'alitajs-dform-radio-label': true,
-            [className]: className
-          })} style={coverStyle}>
+          <div
+            className={classnames({
+              'alitajs-dform-radio-label': true,
+              [className]: className,
+            })}
+            style={coverStyle}
+          >
             {item.label}
           </div>
         </div>


### PR DESCRIPTION
- 新增allowUnChecked props 用以控制是否支持取消选中
- 犹豫原有的代码逻辑天生就支持 取消选中，因此为了不造成不兼容的更新，默认值设定为 true